### PR TITLE
Add missing @ConditionalOnMissingBean annotations

### DIFF
--- a/spring-security-oauth2-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
+++ b/spring-security-oauth2-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/ResourceServerTokenServicesConfiguration.java
@@ -277,6 +277,7 @@ public class ResourceServerTokenServicesConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnMissingBean(JwtAccessTokenConverter.class)
 		public JwtAccessTokenConverter jwtTokenEnhancer() {
 			JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
 			String keyValue = this.resource.getJwt().getKeyValue();
@@ -356,6 +357,7 @@ public class ResourceServerTokenServicesConfiguration {
 		}
 
 		@Bean
+		@ConditionalOnMissingBean(JwtAccessTokenConverter.class)
 		public JwtAccessTokenConverter accessTokenConverter() {
 			Assert.notNull(this.resource.getJwt().getKeyStore(),
 					"keyStore cannot be null");


### PR DESCRIPTION
The jwtTokenEnhancer bean can no longer be overridden in it's current state. The proposed changes seem to be necessary as a result of the changes related to #13609.